### PR TITLE
[Feat] BaseTimeEntity 생성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/team/sparta/onehouronemeal/OneHourOneMealApplication.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/OneHourOneMealApplication.kt
@@ -2,7 +2,9 @@ package team.sparta.onehouronemeal
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
+@EnableJpaAuditing
 @SpringBootApplication
 class OneHourOneMealApplication
 

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/common/BaseTimeEntity.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/common/BaseTimeEntity.kt
@@ -1,0 +1,21 @@
+package team.sparta.onehouronemeal.domain.common
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.hibernate.annotations.CreationTimestamp
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    val createdAt: LocalDateTime? = null
+
+    @LastModifiedDate
+    @Column(insertable = false, nullable = true)
+    var updatedAt: LocalDateTime? = null
+}


### PR DESCRIPTION
## 요약
엔티티에서 중복되는 생성일, 수정일 컬럼을 BaseTimeEntity로 분리. auditing을 적용하여 insert, update시 자동 적용

## 작업 사항
- spring data jpa 의존성 추가
- BaseTimeEntity 생성
- auditing 적용

## 리뷰 요청 사항

BaseTimeEntity 패키지 위치가 괜찮은가요

---
### 해결한 이슈
closes: #12 
