### PR TITLE
[Feat] Course CRUD 구현

### DIFF
--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/course/controller/v1/CourseController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/course/controller/v1/CourseController.kt
@@ -42,8 +42,7 @@ class CourseController(
 
     @PostMapping
     fun createCourse(
-        @AuthenticationPrincipal principal: UserPrincipal,
-        @RequestBody request: CreateCourseRequest
+        @AuthenticationPrincipal principal: UserPrincipal, @RequestBody request: CreateCourseRequest
     ): ResponseEntity<CourseResponse> {
         return ResponseEntity.status(HttpStatus.CREATED).body(courseService.createCourse(principal, request))
     }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/course/dto/v1/CourseResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/course/dto/v1/CourseResponse.kt
@@ -1,11 +1,12 @@
 package team.sparta.onehouronemeal.domain.course.dto.v1
 
 import team.sparta.onehouronemeal.domain.course.model.v1.Course
+import team.sparta.onehouronemeal.domain.user.dto.v1.UserResponse
 import java.time.LocalDateTime
 
 data class CourseResponse(
     val id: Long,
-    val nickname: String,
+    val user: UserResponse,
     val title: String,
     val describe: String,
     val status: String,
@@ -13,10 +14,10 @@ data class CourseResponse(
     val updatedAt: LocalDateTime?
 ) {
     companion object {
-        fun from(course: Course, nickname: String): CourseResponse {
+        fun from(course: Course): CourseResponse {
             return CourseResponse(
                 id = course.id!!,
-                nickname = nickname,
+                user = UserResponse.from(course.user),
                 title = course.title,
                 describe = course.describe,
                 status = course.status.name,

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/course/dto/v1/CourseResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/course/dto/v1/CourseResponse.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 
 data class CourseResponse(
     val id: Long,
-    val chefId: Long,
+    val nickname: String,
     val title: String,
     val describe: String,
     val status: String,
@@ -13,10 +13,10 @@ data class CourseResponse(
     val updatedAt: LocalDateTime?
 ) {
     companion object {
-        fun from(course: Course): CourseResponse {
+        fun from(course: Course, nickname: String): CourseResponse {
             return CourseResponse(
                 id = course.id!!,
-                chefId = course.user.id!!,
+                nickname = nickname,
                 title = course.title,
                 describe = course.describe,
                 status = course.status.name,

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/course/model/v1/Course.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/course/model/v1/Course.kt
@@ -31,7 +31,7 @@ class Course(
 ) : BaseTimeEntity() {
     fun isOpened() = status == CourseStatus.OPEN
 
-    fun updateCourse(title: String, description: String) {
+    fun updateCourse(title: String, describe: String) {
         this.title = title
         this.describe = describe
     }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/course/model/v1/Course.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/course/model/v1/Course.kt
@@ -9,11 +9,17 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
 import team.sparta.onehouronemeal.domain.common.BaseTimeEntity
 import team.sparta.onehouronemeal.domain.user.model.v1.User
 
 @Entity
+@Table(name = "course")
 class Course(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
     @Column var title: String,
 
     @Column var describe: String,
@@ -23,7 +29,10 @@ class Course(
     @ManyToOne(fetch = FetchType.LAZY) var user: User
 
 ) : BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long? = null
+    fun isOpened() = status == CourseStatus.OPEN
+
+    fun updateCourse(title: String, description: String) {
+        this.title = title
+        this.describe = describe
+    }
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/course/repository/v1/CourseRepository.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/course/repository/v1/CourseRepository.kt
@@ -2,5 +2,8 @@ package team.sparta.onehouronemeal.domain.course.repository.v1
 
 import org.springframework.data.jpa.repository.JpaRepository
 import team.sparta.onehouronemeal.domain.course.model.v1.Course
+import team.sparta.onehouronemeal.domain.course.model.v1.CourseStatus
 
-interface CourseRepository : JpaRepository<Course, Long>, CustomCourseRepository
+interface CourseRepository : JpaRepository<Course, Long>, CustomCourseRepository {
+    fun findAllByStatusIsOrderByCreatedAtDesc(courseStatus: CourseStatus): List<Course>
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserRepository.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserRepository.kt
@@ -7,4 +7,5 @@ interface UserRepository {
     fun findByUsername(username: String): User?
     fun save(user: User): User
     fun delete(user: User)
+    fun existsById(id: Long): Boolean
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserRepositoryImpl.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserRepositoryImpl.kt
@@ -23,4 +23,7 @@ class UserRepositoryImpl(
     override fun delete(user: User) {
         userJpaRepository.delete(user)
     }
+    override fun existsById(id: Long): Boolean {
+        return userJpaRepository.existsById(id)
+    }
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/exception/AccessDeniedException.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/exception/AccessDeniedException.kt
@@ -1,0 +1,7 @@
+package team.sparta.onehouronemeal.exception
+
+data class AccessDeniedException(
+    private val text: String
+): RuntimeException(
+    "Access Denied: $text"
+)

--- a/src/main/kotlin/team/sparta/onehouronemeal/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package team.sparta.onehouronemeal.exception
 
+import org.apache.coyote.Response
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -27,5 +28,10 @@ class GlobalExceptionHandler {
     @ExceptionHandler(RuntimeException::class)
     fun handleRuntimeException(e: RuntimeException): ResponseEntity<ErrorDto> {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorDto(e.message, "500"))
+    }
+
+    @ExceptionHandler(AccessDeniedException::class)
+    fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<ErrorDto> {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorDto(e.message, "403"))
     }
 }


### PR DESCRIPTION
## 요약
Course의 CRUD를 구현하였습니다.

## 작업 사항
- Course의 전체 Course 조회(생성시간 내림차순), 단건 조회, 생성, 수정, 삭제 구현을 완료하였습니다.
- 작성자 본인이 아니면 수정, 삭제가 불가능합니다.
- 팔로우한 셰프의 Course 조회, 좋아요 POST, DELETE는 구현하지 않았습니다.
- 현재 Course를 새로 생성하면 PENDING에서 OPEN으로 바꿀 수 없기 때문에 조회가 안되는 것이 정상입니다.
- 예외처리의 경우도 추후에 수정이 필요한데, 아이디어가 있다면 남겨주세요

## 리뷰 요청 사항(선택)
Response 부분에서 nickname을 처리하는 부분 저렇게 해도 괜찮을까요?
예외처리 어떻게 하면 좋을까요? 의견 주시면 바꿔놓겠습니다.

---
### 해결한 이슈
closes: #18 
