### PR TITLE
:sparkles: 최초 테스트용 회원가입시 ADMIN 처리 및 ADMIN 일반 회원가입 예외처리

### DIFF
--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/SignUpRequest.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/SignUpRequest.kt
@@ -13,6 +13,9 @@ data class SignUpRequest(
 ) {
     fun to(encoder: PasswordEncoder, role: String): User {
         val actualRole = UserRole.valueOf(role)
+
+        if (actualRole == UserRole.ADMIN) throw IllegalArgumentException("Admin cannot be created by sign up")
+
         val status = if (actualRole == UserRole.CHEF) UserStatus.PENDING else UserStatus.ACTIVE
 
         return User(

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -13,6 +13,7 @@ import team.sparta.onehouronemeal.domain.user.dto.v1.UpdateUserRequest
 import team.sparta.onehouronemeal.domain.user.dto.v1.UserResponse
 import team.sparta.onehouronemeal.domain.user.model.v1.Profile
 import team.sparta.onehouronemeal.domain.user.model.v1.User
+import team.sparta.onehouronemeal.domain.user.model.v1.UserRole
 import team.sparta.onehouronemeal.domain.user.repository.v1.UserJpaRepository
 import team.sparta.onehouronemeal.exception.ModelNotFoundException
 import team.sparta.onehouronemeal.infra.security.UserPrincipal
@@ -60,16 +61,18 @@ class UserService(
             ?: throw ModelNotFoundException("User not found with id", userId)
     }
 
+    @Transactional
     fun tokenTestGenerate(): SignInResponse {
-        val testUser = userRepository.findByIdOrNull(1) ?: userRepository.save(
-            User(
-                username = "test",
-                password = "12345678",
-                profile = Profile(nickname = "testNickname"),
-            )
-        )
-
-        return SignInResponse.from(jwtPlugin = jwtPlugin, user = testUser)
+        return (userRepository.findByIdOrNull(1)
+            ?: userRepository.save(
+                User(
+                    username = "test",
+                    password = "12345678",
+                    profile = Profile(nickname = "testAdminNickname"),
+                    role = UserRole.ADMIN
+                )
+            ))
+            .let { SignInResponse.from(jwtPlugin = jwtPlugin, user = it) }
     }
 
     fun tokenTestCheck(accessToken: String, principal: UserPrincipal): TokenCheckResponse {


### PR DESCRIPTION
## 요약
> 간단 요약

/api/v1/auth/token-test-generate시 최초 유저는 ADMIN으로 생성됩니다. 일반 유저 / 쉐프 테스트를 위해선 /api/v1/auth/sign-up/{role} 을 추천드립니다.

## 작업 사항

> PR에서 작업한 사항들을 적어주세요(이미지, 스크린샷등을 활용해도 좋아요)

## 리뷰 요청 사항(선택)

> 리뷰시 봐주었으면 하는 부분이 있다면 적어주세요

보통 백오피스에서 기존 유저의 권한을 바꾸는게 가능한 식으로 ADMIN이 설정하거나 가입시키는 걸로 알아서 ADMIN용 회원가입 자체는 우선 만들지 않았습니다.


---
### 해결한 이슈
closes: #51
