### PR TITLE
:sparkles: CourseResponseDto 추가

### DIFF
--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/admin/controller/v1/AdminController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/admin/controller/v1/AdminController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.sparta.onehouronemeal.domain.admin.service.v1.AdminService
-import team.sparta.onehouronemeal.domain.course.dto.v1.CourseResponse
+import team.sparta.onehouronemeal.domain.course.dto.v1.PendingCourseResponse
 import team.sparta.onehouronemeal.domain.user.dto.v1.UserResponse
 
 @RestController
@@ -36,7 +36,7 @@ class AdminController(
     }
 
     @GetMapping("/courses/pending")
-    fun getPendingCourseList(): ResponseEntity<List<CourseResponse>> {
+    fun getPendingCourseList(): ResponseEntity<List<PendingCourseResponse>> {
         return ResponseEntity.ok(adminService.getPendingCourseList())
     }
 

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/admin/service/v1/AdminService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/admin/service/v1/AdminService.kt
@@ -3,7 +3,7 @@ package team.sparta.onehouronemeal.domain.admin.service.v1
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.sparta.onehouronemeal.domain.course.dto.v1.CourseResponse
+import team.sparta.onehouronemeal.domain.course.dto.v1.PendingCourseResponse
 import team.sparta.onehouronemeal.domain.course.model.v1.CourseStatus
 import team.sparta.onehouronemeal.domain.course.repository.v1.CourseRepository
 import team.sparta.onehouronemeal.domain.user.dto.v1.UserResponse
@@ -34,9 +34,9 @@ class AdminService(
         user.changeStatus(UserStatus.DENIED)
     }
 
-    fun getPendingCourseList(): List<CourseResponse>? {
+    fun getPendingCourseList(): List<PendingCourseResponse>? {
         return courseRepository.findAllByStatusIsOrderByCreatedAtDesc(CourseStatus.PENDING)
-            .map { CourseResponse.from(it) }
+            .map { PendingCourseResponse.from(it) }
     }
 
     @Transactional

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/course/controller/v1/CourseController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/course/controller/v1/CourseController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.sparta.onehouronemeal.domain.course.dto.v1.CourseResponse
+import team.sparta.onehouronemeal.domain.course.dto.v1.CourseResponseWithRecipes
 import team.sparta.onehouronemeal.domain.course.dto.v1.CreateCourseRequest
 import team.sparta.onehouronemeal.domain.course.dto.v1.UpdateCourseRequest
 import team.sparta.onehouronemeal.domain.course.service.v1.CourseService
@@ -36,7 +37,7 @@ class CourseController(
     }
 
     @GetMapping("/{courseId}")
-    fun getCourse(@PathVariable courseId: Long): ResponseEntity<CourseResponse> {
+    fun getCourse(@PathVariable courseId: Long): ResponseEntity<CourseResponseWithRecipes> {
         return ResponseEntity.ok(courseService.getCourse(courseId))
     }
 

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/course/dto/v1/CourseResponseWithRecipes.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/course/dto/v1/CourseResponseWithRecipes.kt
@@ -1,0 +1,34 @@
+package team.sparta.onehouronemeal.domain.course.dto.v1
+
+import team.sparta.onehouronemeal.domain.course.model.v1.Course
+import team.sparta.onehouronemeal.domain.recipe.dto.v1.RecipeResponse
+import team.sparta.onehouronemeal.domain.user.dto.v1.UserResponse
+import java.time.LocalDateTime
+
+data class CourseResponseWithRecipes(
+    val id: Long,
+    val user: UserResponse,
+    val title: String,
+    val describe: String,
+    val status: String,
+    val thumbsUpCount: Int,
+    val recipeList: List<RecipeResponse>,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(course: Course, thumbsUpCount: Int, recipeList: List<RecipeResponse>): CourseResponseWithRecipes {
+            return CourseResponseWithRecipes(
+                id = course.id!!,
+                user = UserResponse.from(course.user),
+                title = course.title,
+                describe = course.describe,
+                status = course.status.name,
+                thumbsUpCount = thumbsUpCount,
+                recipeList = recipeList,
+                createdAt = course.createdAt,
+                updatedAt = course.updatedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/course/dto/v1/PendingCourseResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/course/dto/v1/PendingCourseResponse.kt
@@ -1,0 +1,29 @@
+package team.sparta.onehouronemeal.domain.course.dto.v1
+
+import team.sparta.onehouronemeal.domain.course.model.v1.Course
+import team.sparta.onehouronemeal.domain.user.dto.v1.UserResponse
+import java.time.LocalDateTime
+
+data class PendingCourseResponse(
+    val id: Long,
+    val user: UserResponse,
+    val title: String,
+    val describe: String,
+    val status: String,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(course: Course): PendingCourseResponse {
+            return PendingCourseResponse(
+                id = course.id!!,
+                user = UserResponse.from(course.user),
+                title = course.title,
+                describe = course.describe,
+                status = course.status.name,
+                createdAt = course.createdAt,
+                updatedAt = course.updatedAt
+            )
+        }
+    }
+}


### PR DESCRIPTION

## 요약
하나 있던 Course에 대한 Reponse Dto 2개를 추가해주었습니다.

## 작업 사항

- 3개의 Course에 대한 Response 작성 및 연결을 완료하였습니다.
  - 전체 조회(Course 아래에 있는 Recipe들 조회 제외) CourseResponse
  - 단건 조회(Recipe들 까지 모두 조회) CourseResponseWithRecipes
  - 관리자(Admin)가 PENDING 상태의 Course 조회(좋아요 갯수, Recipe들 조회 제외) PendingCourseResponse

## 리뷰 요청 사항(선택)

Response 이름이 괜찮은가요?

---
### 해결한 이슈
closes: #61 
