### PR TITLE
✨ OAuth2 소셜 로그인

### DIFF
--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/UserResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/UserResponse.kt
@@ -11,6 +11,7 @@ data class UserResponse(
     val status: String,
     val profileImageUrl: String? = null,
     val provider: String? = null,
+    val providerId: String? = null,
     val createdAt: LocalDateTime?,
     val updatedAt: LocalDateTime?,
     val subscribedChefList: List<SubscriptionResponse>?,
@@ -24,6 +25,7 @@ data class UserResponse(
                 status = user.status.name,
                 profileImageUrl = user.profile.profileImageUrl,
                 provider = user.provider,
+                providerId = user.providerId,
                 createdAt = user.createdAt,
                 updatedAt = user.updatedAt,
                 subscribedChefList = subscribedChefList?.map { SubscriptionResponse.from(it) }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/User.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/User.kt
@@ -20,7 +20,7 @@ class User(
     val username: String,
 
     @Column(name = "password")
-    @Size(max = 30)
+    @Size(max = 60)
     val password: String,
 
     @Embedded

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserJpaRepository.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserJpaRepository.kt
@@ -8,4 +8,5 @@ interface UserJpaRepository : JpaRepository<User, Long> {
     fun findByUsername(username: String): User?
     fun findByStatusOrderByCreatedAtDesc(status: UserStatus): List<User>
     fun existsByUsername(username: String): Boolean
+    fun findByProviderAndProviderId(provider: String, providerId: String): User?
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserRepository.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserRepository.kt
@@ -6,9 +6,12 @@ import team.sparta.onehouronemeal.domain.user.model.v1.UserStatus
 interface UserRepository {
     fun findById(id: Long): User?
     fun findByUsername(username: String): User?
+    fun findByStatusOrderByCreatedAtDesc(status: UserStatus): List<User>
+    fun findByProviderAndProviderId(provider: String, providerId: String): User?
+
+    fun existsById(id: Long): Boolean
+    fun existsByUsername(username: String): Boolean
+
     fun save(user: User): User
     fun delete(user: User)
-    fun existsById(id: Long): Boolean
-    fun findByStatusOrderByCreatedAtDesc(status: UserStatus): List<User>
-    fun existsByUsername(username: String): Boolean
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserRepositoryImpl.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/UserRepositoryImpl.kt
@@ -33,6 +33,10 @@ class UserRepositoryImpl(
         return userJpaRepository.findByStatusOrderByCreatedAtDesc(status)
     }
 
+    override fun findByProviderAndProviderId(provider: String, providerId: String): User? {
+        return userJpaRepository.findByProviderAndProviderId(provider, providerId)
+    }
+
     override fun existsByUsername(username: String): Boolean {
         return userJpaRepository.existsByUsername(username)
     }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -92,11 +92,11 @@ class UserService(
         return TokenCheckResponse.from(userId, role)
     }
 
-    fun registerIfAbsentWithOAuth(info: OAuth2UserInfo): UserResponse {
+    fun registerIfAbsentWithOAuth(info: OAuth2UserInfo): SignInResponse {
         run {
             userRepository.findByProviderAndProviderId(info.provider.name, info.id)
                 ?: userRepository.save(info.to(passwordEncoder))
-        }.let { return UserResponse.from(it) }
+        }.let { return SignInResponse.from(jwtPlugin, it) }
     }
 
     fun subscribeChef(principal: UserPrincipal, chefId: Long): SubscriptionResponse {

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -20,6 +20,7 @@ import team.sparta.onehouronemeal.domain.user.repository.v1.UserRepository
 import team.sparta.onehouronemeal.domain.user.repository.v1.subscription.SubscriptionRepository
 import team.sparta.onehouronemeal.exception.AccessDeniedException
 import team.sparta.onehouronemeal.exception.ModelNotFoundException
+import team.sparta.onehouronemeal.infra.oauth.client.dto.OAuth2UserInfo
 import team.sparta.onehouronemeal.infra.security.UserPrincipal
 import team.sparta.onehouronemeal.infra.security.jwt.JwtPlugin
 
@@ -89,6 +90,13 @@ class UserService(
         val role = principal.role
 
         return TokenCheckResponse.from(userId, role)
+    }
+
+    fun registerIfAbsentWithOAuth(info: OAuth2UserInfo): UserResponse {
+        run {
+            userRepository.findByProviderAndProviderId(info.provider.name, info.id)
+                ?: userRepository.save(info.to(passwordEncoder))
+        }.let { return UserResponse.from(it) }
     }
 
     fun subscribeChef(principal: UserPrincipal, chefId: Long): SubscriptionResponse {

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -93,10 +93,10 @@ class UserService(
     }
 
     fun registerIfAbsentWithOAuth(info: OAuth2UserInfo): SignInResponse {
-        run {
+        return run {
             userRepository.findByProviderAndProviderId(info.provider.name, info.id)
                 ?: userRepository.save(info.to(passwordEncoder))
-        }.let { return SignInResponse.from(jwtPlugin, it) }
+        }.let { SignInResponse.from(jwtPlugin, it) }
     }
 
     fun subscribeChef(principal: UserPrincipal, chefId: Long): SubscriptionResponse {

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/OAuth2Client.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/OAuth2Client.kt
@@ -1,0 +1,11 @@
+package team.sparta.onehouronemeal.infra.oauth.client
+
+import team.sparta.onehouronemeal.infra.oauth.client.dto.OAuth2UserInfo
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+
+interface OAuth2Client {
+    fun redirectUrl(): String
+    fun getAccessToken(code: String): String
+    fun getUserInfo(accessToken: String): OAuth2UserInfo
+    fun supports(provider: OAuth2Provider): Boolean
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/OAuth2ClientService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/OAuth2ClientService.kt
@@ -1,0 +1,25 @@
+package team.sparta.onehouronemeal.infra.oauth.client
+
+import jakarta.transaction.NotSupportedException
+import org.springframework.stereotype.Service
+import team.sparta.onehouronemeal.infra.oauth.client.dto.OAuth2UserInfo
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+
+@Service
+class OAuth2ClientService(
+    private val clients: List<OAuth2Client>
+) {
+    fun redirectUrlBy(provider: OAuth2Provider): String {
+        return selectClient(provider).redirectUrl()
+    }
+
+    fun login(provider: OAuth2Provider, authorizationCode: String): OAuth2UserInfo {
+        val client = selectClient(provider)
+        return client.getAccessToken(authorizationCode)
+            .let { client.getUserInfo(it) }
+    }
+
+    private fun selectClient(provider: OAuth2Provider): OAuth2Client {
+        return clients.find { it.supports(provider) } ?: throw NotSupportedException("지원하지 않는 OAuth Provider 입니다.")
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/dto/OAuth2UserInfo.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/dto/OAuth2UserInfo.kt
@@ -1,0 +1,36 @@
+package team.sparta.onehouronemeal.infra.oauth.client.dto
+
+import org.springframework.security.crypto.password.PasswordEncoder
+import team.sparta.onehouronemeal.domain.user.model.v1.Profile
+import team.sparta.onehouronemeal.domain.user.model.v1.User
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+import kotlin.random.Random
+
+open class OAuth2UserInfo(
+    val provider: OAuth2Provider,
+    val id: String,
+    val nickname: String,
+    val profileImageUrl: String,
+) {
+    fun to(encoder: PasswordEncoder): User {
+        return User(
+            username = generateUsername(id.hashCode().toLong()),
+            password = encoder.encode(id),
+            provider = provider.name,
+            providerId = id,
+            profile = Profile(
+                nickname = nickname,
+                profileImageUrl = profileImageUrl,
+            ),
+        )
+    }
+
+    private fun generateUsername(seed: Long): String {
+        val allowedChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        val random = Random(seed)
+
+        return (1..28)
+            .map { allowedChars[random.nextInt(allowedChars.length)] }
+            .joinToString("")
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/kakao/KakaoOAuth2Client.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/kakao/KakaoOAuth2Client.kt
@@ -1,0 +1,69 @@
+package team.sparta.onehouronemeal.infra.oauth.client.kakao
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
+import team.sparta.onehouronemeal.infra.oauth.client.OAuth2Client
+import team.sparta.onehouronemeal.infra.oauth.client.dto.OAuth2UserInfo
+import team.sparta.onehouronemeal.infra.oauth.client.kakao.dto.KakaoTokenResponse
+import team.sparta.onehouronemeal.infra.oauth.client.kakao.dto.KakaoUserInfoResponse
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+
+@Component
+class KakaoOAuth2Client(
+    @Value("\${kakao.client.id}") val clientId: String,
+    @Value("\${kakao.redirect.url}") val redirectUrl: String,
+    @Value("\${kakao.api.auth_url}") val authUrl: String,
+    @Value("\${kakao.api.token_url}") val tokenUrl: String,
+    @Value("\${kakao.api.profile_url}") val userUrl: String,
+    private val restClient: RestClient
+) : OAuth2Client {
+
+    override fun redirectUrl(): String {
+        return StringBuilder(authUrl)
+            .append("?client_id=").append(clientId)
+            .append("&redirect_uri=").append(redirectUrl)
+            .append("&response_type=").append("code")
+            .toString()
+    }
+
+    override fun getAccessToken(code: String): String {
+        val requestData = mutableMapOf(
+            "grant_type" to "authorization_code",
+            "client_id" to clientId,
+            "code" to code
+        )
+
+        return restClient.post()
+            .uri(tokenUrl)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(LinkedMultiValueMap<String, String>().apply { this.setAll(requestData) })
+            .retrieve()
+            .onStatus(HttpStatusCode::isError) { _, _ ->
+                throw RuntimeException("카카오 AccessToken 조회 실패")
+            }
+            .body<KakaoTokenResponse>()
+            ?.accessToken
+            ?: throw RuntimeException("카카오 AccessToken 조회 실패")
+    }
+
+    override fun getUserInfo(accessToken: String): OAuth2UserInfo {
+        return restClient.get()
+            .uri(userUrl)
+            .header("Authorization", "Bearer $accessToken")
+            .retrieve()
+            .onStatus(HttpStatusCode::isError) { _, _ ->
+                throw RuntimeException("카카오 UserInfo 조회 실패")
+            }
+            .body<KakaoUserInfoResponse>()
+            ?: throw RuntimeException("카카오 UserInfo 조회 실패")
+    }
+
+    override fun supports(provider: OAuth2Provider): Boolean {
+        return provider == OAuth2Provider.KAKAO
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/kakao/dto/KakaoTokenResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/kakao/dto/KakaoTokenResponse.kt
@@ -1,0 +1,8 @@
+package team.sparta.onehouronemeal.infra.oauth.client.kakao.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class KakaoTokenResponse(
+    @JsonProperty("access_token")
+    val accessToken: String,
+)

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/kakao/dto/KakaoUserInfoResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/kakao/dto/KakaoUserInfoResponse.kt
@@ -1,0 +1,22 @@
+package team.sparta.onehouronemeal.infra.oauth.client.kakao.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import team.sparta.onehouronemeal.infra.oauth.client.dto.OAuth2UserInfo
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+
+class KakaoUserInfoResponse(
+    id: Long,
+    properties: KakaoUserInfoPropertiesResponse
+) : OAuth2UserInfo(
+    provider = OAuth2Provider.KAKAO,
+    id = id.toString(),
+    nickname = properties.nickname,
+    profileImageUrl = properties.profileImageUrl
+)
+
+data class KakaoUserInfoPropertiesResponse(
+    val nickname: String,
+    @JsonProperty("profile_image")
+    val profileImageUrl: String
+)
+

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/naver/NaverOAuth2Client.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/naver/NaverOAuth2Client.kt
@@ -1,0 +1,71 @@
+package team.sparta.onehouronemeal.infra.oauth.client.naver
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
+import team.sparta.onehouronemeal.infra.oauth.client.OAuth2Client
+import team.sparta.onehouronemeal.infra.oauth.client.dto.OAuth2UserInfo
+import team.sparta.onehouronemeal.infra.oauth.client.naver.dto.NaverTokenResponse
+import team.sparta.onehouronemeal.infra.oauth.client.naver.dto.NaverUserInfoResponse
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+
+@Component
+class NaverOAuth2Client(
+    @Value("\${naver.client.id}") val clientId: String,
+    @Value("\${naver.client.secret}") val secret: String,
+    @Value("\${naver.redirect.url}") val redirectUrl: String,
+    @Value("\${naver.api.auth_url}") val authUrl: String,
+    @Value("\${naver.api.token_url}") val tokenUrl: String,
+    @Value("\${naver.api.profile_url}") val userUrl: String,
+    private val restClient: RestClient
+) : OAuth2Client {
+    override fun redirectUrl(): String {
+        return authUrl +
+            "?client_id=${clientId}" +
+            "&redirect_uri=${redirectUrl}" +
+            "&state=test" +
+            "&response_type=code"
+    }
+
+    override fun getAccessToken(code: String): String {
+        val requestData = mutableMapOf(
+            "grant_type" to "authorization_code",
+            "client_id" to clientId,
+            "client_secret" to secret,
+            "code" to code,
+            "state" to "test"
+        )
+
+        return restClient.post()
+            .uri(tokenUrl)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(LinkedMultiValueMap<String, String>().apply { this.setAll(requestData) })
+            .retrieve()
+            .onStatus(HttpStatusCode::isError) { _, _ ->
+                throw RuntimeException("네이버 AccessToken 조회 실패")
+            }
+            .body<NaverTokenResponse>()
+            ?.accessToken
+            ?: throw RuntimeException("네이버 AccessToken 조회 실패")
+    }
+
+    override fun getUserInfo(accessToken: String): OAuth2UserInfo {
+        return restClient.get()
+            .uri(userUrl)
+            .header("Authorization", "Bearer $accessToken")
+            .retrieve()
+            .onStatus(HttpStatusCode::isError) { _, _ ->
+                throw RuntimeException("네이버 UserInfo 조회 실패")
+            }
+            .body<NaverUserInfoResponse>()
+            ?: throw RuntimeException("네이버 UserInfo 조회 실패")
+    }
+
+    override fun supports(provider: OAuth2Provider): Boolean {
+        return provider == OAuth2Provider.NAVER
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/naver/dto/NaverTokenResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/naver/dto/NaverTokenResponse.kt
@@ -1,0 +1,8 @@
+package team.sparta.onehouronemeal.infra.oauth.client.naver.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class NaverTokenResponse(
+    @JsonProperty("access_token")
+    val accessToken: String,
+)

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/naver/dto/NaverUserInfoResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/naver/dto/NaverUserInfoResponse.kt
@@ -5,9 +5,7 @@ import team.sparta.onehouronemeal.infra.oauth.client.dto.OAuth2UserInfo
 import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
 
 class NaverUserInfoResponse(
-    @JsonProperty("resultcode")
-    val resultCode: String,
-    val message: String,
+    @JsonProperty("response")
     response: NaverUserInfoDetailResponse
 ) : OAuth2UserInfo(
     provider = OAuth2Provider.NAVER,

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/naver/dto/NaverUserInfoResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/client/naver/dto/NaverUserInfoResponse.kt
@@ -1,0 +1,27 @@
+package team.sparta.onehouronemeal.infra.oauth.client.naver.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import team.sparta.onehouronemeal.infra.oauth.client.dto.OAuth2UserInfo
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+
+class NaverUserInfoResponse(
+    @JsonProperty("resultcode")
+    val resultCode: String,
+    val message: String,
+    response: NaverUserInfoDetailResponse
+) : OAuth2UserInfo(
+    provider = OAuth2Provider.NAVER,
+    id = response.id,
+    nickname = response.nickname,
+    profileImageUrl = response.profileImageUrl
+)
+
+data class NaverUserInfoDetailResponse(
+    val id: String,
+    val nickname: String,
+    val email: String,
+    val name: String,
+    @JsonProperty("profile_image")
+    val profileImageUrl: String
+)
+

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/common/OAuth2Provider.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/common/OAuth2Provider.kt
@@ -1,0 +1,6 @@
+package team.sparta.onehouronemeal.infra.oauth.common
+
+enum class OAuth2Provider {
+    KAKAO,
+    NAVER
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/config/OAuthWebConfig.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/config/OAuthWebConfig.kt
@@ -1,0 +1,13 @@
+package team.sparta.onehouronemeal.infra.oauth.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.format.FormatterRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import team.sparta.onehouronemeal.infra.oauth.util.OAuth2ProviderConverter
+
+@Configuration
+class OAuthWebConfig(private val oauth2ProviderConverter: OAuth2ProviderConverter) : WebMvcConfigurer {
+    override fun addFormatters(registry: FormatterRegistry) {
+        registry.addConverter(oauth2ProviderConverter)
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/config/RestClientConfig.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/config/RestClientConfig.kt
@@ -1,0 +1,14 @@
+package team.sparta.onehouronemeal.infra.oauth.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+
+@Configuration
+class RestClientConfig {
+
+    @Bean
+    fun restClient(): RestClient {
+        return RestClient.builder().build()
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/controller/OAuthController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/controller/OAuthController.kt
@@ -1,0 +1,33 @@
+package team.sparta.onehouronemeal.infra.oauth.controller
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import team.sparta.onehouronemeal.infra.oauth.client.OAuth2ClientService
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+import team.sparta.onehouronemeal.infra.oauth.service.OAuth2LoginService
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class OAuth2LoginController(
+    private val oauth2LoginService: OAuth2LoginService,
+    private val oauth2ClientService: OAuth2ClientService
+) {
+
+    @GetMapping("/oauth2/{provider}/login")
+    fun redirectLoginPage(@PathVariable provider: OAuth2Provider, response: HttpServletResponse) {
+        oauth2ClientService.redirectUrlBy(provider)
+            .let { response.sendRedirect(it) }
+    }
+
+    @GetMapping("/oauth2/{provider}/callback")
+    fun callback(
+        @PathVariable provider: OAuth2Provider,
+        @RequestParam(name = "code") code: String
+    ): String {
+        return oauth2LoginService.login(provider, code)
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/controller/OAuthController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/controller/OAuthController.kt
@@ -1,11 +1,14 @@
 package team.sparta.onehouronemeal.infra.oauth.controller
 
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import team.sparta.onehouronemeal.domain.user.dto.v1.SignInResponse
 import team.sparta.onehouronemeal.infra.oauth.client.OAuth2ClientService
 import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
 import team.sparta.onehouronemeal.infra.oauth.service.OAuth2LoginService
@@ -27,7 +30,7 @@ class OAuth2LoginController(
     fun callback(
         @PathVariable provider: OAuth2Provider,
         @RequestParam(name = "code") code: String
-    ): String {
-        return oauth2LoginService.login(provider, code)
+    ): ResponseEntity<SignInResponse> {
+        return ResponseEntity.status(HttpStatus.OK).body(oauth2LoginService.login(provider, code))
     }
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/service/OAuth2LoginService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/service/OAuth2LoginService.kt
@@ -1,25 +1,18 @@
 package team.sparta.onehouronemeal.infra.oauth.service
 
 import org.springframework.stereotype.Service
+import team.sparta.onehouronemeal.domain.user.dto.v1.SignInResponse
 import team.sparta.onehouronemeal.domain.user.service.v1.UserService
 import team.sparta.onehouronemeal.infra.oauth.client.OAuth2ClientService
 import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
-import team.sparta.onehouronemeal.infra.security.jwt.JwtPlugin
 
 @Service
 class OAuth2LoginService(
     private val oauth2Client: OAuth2ClientService,
-    private val userService: UserService,
-    private val jwtPlugin: JwtPlugin
+    private val userService: UserService
 ) {
-    fun login(provider: OAuth2Provider, authorizationCode: String): String {
+    fun login(provider: OAuth2Provider, authorizationCode: String): SignInResponse {
         return oauth2Client.login(provider, authorizationCode)
             .let { userService.registerIfAbsentWithOAuth(it) }
-            .let {
-                jwtPlugin.generateAccessToken(
-                    subject = it.userId.toString(),
-                    role = it.role
-                )
-            }
     }
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/service/OAuth2LoginService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/service/OAuth2LoginService.kt
@@ -1,0 +1,25 @@
+package team.sparta.onehouronemeal.infra.oauth.service
+
+import org.springframework.stereotype.Service
+import team.sparta.onehouronemeal.domain.user.service.v1.UserService
+import team.sparta.onehouronemeal.infra.oauth.client.OAuth2ClientService
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+import team.sparta.onehouronemeal.infra.security.jwt.JwtPlugin
+
+@Service
+class OAuth2LoginService(
+    private val oauth2Client: OAuth2ClientService,
+    private val userService: UserService,
+    private val jwtPlugin: JwtPlugin
+) {
+    fun login(provider: OAuth2Provider, authorizationCode: String): String {
+        return oauth2Client.login(provider, authorizationCode)
+            .let { userService.registerIfAbsentWithOAuth(it) }
+            .let {
+                jwtPlugin.generateAccessToken(
+                    subject = it.userId.toString(),
+                    role = it.role
+                )
+            }
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/util/OAuth2ProviderConverter.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/oauth/util/OAuth2ProviderConverter.kt
@@ -1,0 +1,12 @@
+package team.sparta.onehouronemeal.infra.oauth.util
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.stereotype.Component
+import team.sparta.onehouronemeal.infra.oauth.common.OAuth2Provider
+
+@Component
+class OAuth2ProviderConverter : Converter<String, OAuth2Provider> {
+    override fun convert(source: String): OAuth2Provider? {
+        return OAuth2Provider.entries.firstOrNull { it.name.equals(source, ignoreCase = true) }
+    }
+}


### PR DESCRIPTION
## 요약
> 간단 요약

![oauth_flow](https://github.com/one-day-one-meal/one-hour-one-meal/assets/11582792/10dd72f6-a414-4d9d-ba3e-7054ef3e9acb)


박찬준 튜터님의 OAuth flow를 토대로 작성되었습니다.

용어:
- Provider: 카카오, 네이버같은 OAuth2 인증 제공자 입니다
- redirect: 들어온 요청을 다른 url 로 재요청 처리하는 행위입니다. 그래서 redirectUrl은 재요청 보낼 url이 됩니다
- Client: 여기서 쓰는 Client는 해당 Provider에 특화된 처리를 구현한 **구현체**입니다.

1. OAuth Controller로 소셜 로그인 요청 들어옴 (/api/v1/auth/oauth2/{provider}/login)
2. OAuth Client Service에서 {provider} 에 해당하는 Client를 선택 (.select)
3. 해당 Client에 Provider로 보내야 하는 redirectUrl 생성 요청 (.redirectUrl)
4. Controller에서 redirectUrl 받아서 HttpServletResponse 에 .sendRedirect 실행
5. Provider측 인증 서버에서 내가 보낸 요청(redirectUrl query에 담긴 정보)를 알아서 막 처리함 (우린 모름)
6. 성공하면 Provider가 내 Controller의 Redirect url로 redirectUrl Authorization code 발급 (이하 코드)
7. 발급받은 코드로 OAuth Login service에 로그인 요청
8. OAuth Login service는 먼저 코드와 함께 Client service에 로그인 **처리** 요청을 보냄
9. OAuth Client service가 받은 코드를 가지고 {provider} 에 해당하는 Client(구현체)에 처리를 요청 (.login) 
10. 코드와 Body에 정보를 담아서 Provider의 Access token을 조회한 후 반환
11. OAuth Client service가 조회한 토큰을 가지고 유저 정보 획득 요청 (.getUserInfo)
12. Provider의 유저 정보 획득 API를 호출해 `OAuth2UserInfo` Dto를 생성 후 최종적으로 OAuth Login service에 반환
13. OAuth Login service는 OAuth2UserInfo 를 User service로 회원가입 및 로그인 요청을 보냄
14. **우리 DB** 회원가입/로그인 처리를 진행하고 jwtPlugin 사용해서 Access token을 생성, 반환
15. OAuth Login service가 Controller에 최종 생성된 **우리** Access token (SignInResponse) 를 반환


파일의 분리가 구체적으로 되어있어 굉장히 복잡해보이지만 사실 코드적으로는 구현 부분이 짧습니다.

책임 정리:
- OAuth Controller
/api/v1/auth/oauth2/{provider}/ 로 들어오는 REST API 요청을 받아 적절한 서비스에 요청 처리해달라고 위임합니다.
**코드 발급** 부분은 우리측 Service의 도움이 필요 없으니 OAuth Client service 에 바로 요청을 보내고
**회원가입 / 로그인** 부분은 우리측 Service의 도움이 필요하니 OAuth Login service 에 요청을 보냅니다.

- OAuth Client service
POJO 인터페이스 `OAuth2Client`를 구현한 적절한 Provider client를 찾고 해당 client에 적절한 요청을 위임하는 service입니다.

- OAuth Client
POJO 인터페이스 `OAuth2Client`를 구현한 구현체입니다.
OAuth2의 흐름에 보통 코드 발급 기반 인증이 사용되므로
  - 코드 발급용 인증 서버에 보낼 Redirect url 만들기 (redirectUrl)
  - 발급받은 코드로 Access token을 획득하는 API 호출하기 (getAccessToken)

가 어떤 소셜 로그인 제공자든 공통되게 필요하고
저희는 발급받은 토큰으로 Provider 의 API들을 이용할 수 있으므로

  - 발급받은 토큰으로 Provider 에 있는 유저 정보를 획득하는 API 호출하기 (getUserInfo)

그리고 Client service에서 알아먹기 쉽게 `나 이 Provider의 구현체에요` 라고 알려주는 (support) 를 구현합니다.

- OAuth Login service
로그인 요청을 위해 관련된 Service에 요청을 위임하는 service입니다.
현재는 회원가입/로그인만 필요하니 OAuth Client service 에 Client에서 필요한 만큼 Provider에 요청을 보내고
Provider가 제공한 정보를 우리가 만든 User service로 보내서 우리 DB에 회원가입 / 로그인 진행을 처리합니다.

그 외 common / config / dto는 저희가 쓰는 거랑 같은 이유로 작성되어 있습니다.

## 작업 사항

> PR에서 작업한 사항들을 적어주세요(이미지, 스크린샷등을 활용해도 좋아요)

 OAuth2 클라이언트를 위한 기본 구조 설정
 Kakao, Naver client 구현
 정상적인 회원가입 처리, username과 password는 랜덤한 문자열로 생성
(단, 우리측 username 중복이 발생할 수 있기에 Provider Id를 Seed로 하는 28글자의 랜덤한 username 을 쓰게 했습니다.)

## 리뷰 요청 사항(선택)

> 리뷰시 봐주었으면 하는 부분이 있다면 적어주세요

---
### 해결한 이슈
closes: #20
