### PR TITLE
✨ AWS S3 저장소를 통한 프로필 이미지 저장 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
+    implementation("com.amazonaws:aws-java-sdk-s3:1.12.741")
 
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
@@ -46,13 +46,15 @@ class UserController(
         return ResponseEntity.status(HttpStatus.OK).body(userService.getUserProfile(userId, principal))
     }
 
-    @PutMapping("/users/{userId}/profiles")
+    @PutMapping("/users/{userId}/profiles", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun updateUserProfile(
         @PathVariable userId: Long,
         @AuthenticationPrincipal principal: UserPrincipal,
-        @RequestBody request: UpdateUserRequest,
+        @RequestPart("request") request: UpdateUserRequest,
+        @RequestPart("image", required = false) image: MultipartFile?
     ): ResponseEntity<UserResponse> {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.updateUserProfile(userId, principal, request))
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(userService.updateUserProfile(userId, principal, request, image))
     }
 
     @PostMapping("/users/subscribe/{chefId}")

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/SignUpRequest.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/SignUpRequest.kt
@@ -9,9 +9,9 @@ import team.sparta.onehouronemeal.domain.user.model.v1.UserStatus
 data class SignUpRequest(
     val username: String,
     val password: String,
-    val nickname: String,
+    val nickname: String
 ) {
-    fun to(encoder: PasswordEncoder, role: String): User {
+    fun to(encoder: PasswordEncoder, role: String, imageUrl: String?): User {
         val actualRole = UserRole.valueOf(role)
 
         if (actualRole == UserRole.ADMIN) throw IllegalArgumentException("Admin cannot be created by sign up")
@@ -23,7 +23,7 @@ data class SignUpRequest(
             password = encoder.encode(password),
             role = actualRole,
             status = status,
-            profile = Profile(nickname = nickname),
+            profile = Profile(nickname = nickname, profileImageUrl = imageUrl),
         )
     }
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/UpdateUserRequest.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/UpdateUserRequest.kt
@@ -6,7 +6,7 @@ import team.sparta.onehouronemeal.domain.user.model.v1.User
 data class UpdateUserRequest(
     val nickname: String
 ) {
-    fun apply(user: User) {
-        user.updateProfile(Profile(nickname))
+    fun apply(user: User, imageUrl: String?) {
+        user.updateProfile(Profile(nickname, imageUrl))
     }
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/Profile.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/Profile.kt
@@ -7,11 +7,7 @@ import jakarta.validation.constraints.Size
 
 @Embeddable
 data class Profile(
-    @Column(name = "nickname")
-    @Size(max = 50)
-    val nickname: String,
-    
-    @Column(name = "profile_image_url")
-    @Lob
-    val profileImageUrl: String? = null,
+    @Column(name = "nickname") @Size(max = 50) val nickname: String,
+
+    @Column(name = "profile_image_url") @Lob val profileImageUrl: String? = null,
 )

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -3,13 +3,8 @@ package team.sparta.onehouronemeal.domain.user.service.v1
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.sparta.onehouronemeal.domain.user.dto.v1.SignInRequest
-import team.sparta.onehouronemeal.domain.user.dto.v1.SignInResponse
-import team.sparta.onehouronemeal.domain.user.dto.v1.SignUpRequest
-import team.sparta.onehouronemeal.domain.user.dto.v1.SubscriptionResponse
-import team.sparta.onehouronemeal.domain.user.dto.v1.TokenCheckResponse
-import team.sparta.onehouronemeal.domain.user.dto.v1.UpdateUserRequest
-import team.sparta.onehouronemeal.domain.user.dto.v1.UserResponse
+import org.springframework.web.multipart.MultipartFile
+import team.sparta.onehouronemeal.domain.user.dto.v1.*
 import team.sparta.onehouronemeal.domain.user.model.v1.Profile
 import team.sparta.onehouronemeal.domain.user.model.v1.User
 import team.sparta.onehouronemeal.domain.user.model.v1.UserRole
@@ -20,6 +15,7 @@ import team.sparta.onehouronemeal.domain.user.repository.v1.UserRepository
 import team.sparta.onehouronemeal.domain.user.repository.v1.subscription.SubscriptionRepository
 import team.sparta.onehouronemeal.exception.AccessDeniedException
 import team.sparta.onehouronemeal.exception.ModelNotFoundException
+import team.sparta.onehouronemeal.infra.s3.S3FileManagement
 import team.sparta.onehouronemeal.infra.security.UserPrincipal
 import team.sparta.onehouronemeal.infra.security.jwt.JwtPlugin
 
@@ -28,13 +24,19 @@ class UserService(
     private val userRepository: UserRepository,
     private val subscriptionRepository: SubscriptionRepository,
     private val passwordEncoder: PasswordEncoder,
-    private val jwtPlugin: JwtPlugin
+    private val jwtPlugin: JwtPlugin,
+    private val s3FileManagement: S3FileManagement
 ) {
     @Transactional
-    fun signUp(role: String, request: SignUpRequest): UserResponse {
+    fun signUp(role: String, request: SignUpRequest, image: MultipartFile?): UserResponse {
+        val imageFileUrl = if (image is MultipartFile) {
+            val imageFileName = s3FileManagement.uploadImage(image)
+            s3FileManagement.getUrl(imageFileName)
+        } else null
+
         check(!userRepository.existsByUsername(request.username)) { "Username already in use" }
-        return request.to(passwordEncoder, role)
-            .let { userRepository.save(it) }
+
+        return request.to(passwordEncoder, role, imageFileUrl).let { userRepository.save(it) }
             .let { UserResponse.from(it) }
     }
 
@@ -52,36 +54,33 @@ class UserService(
     }
 
     fun getUserProfile(userId: Long, principal: UserPrincipal): UserResponse {
-        return userRepository.findById(userId)
-            ?.also { checkPermission(it, principal) }
-            ?.let {
-                val subscribedChefList = subscriptionRepository.findAllByUserId(userId)
-                UserResponse.from(it, subscribedChefList)
-            }
-            ?: throw ModelNotFoundException("User not found with id", userId)
+        return userRepository.findById(userId)?.also { checkPermission(it, principal) }?.let {
+            val subscribedChefList = subscriptionRepository.findAllByUserId(userId)
+            UserResponse.from(it, subscribedChefList)
+        } ?: throw ModelNotFoundException("User not found with id", userId)
     }
 
     @Transactional
-    fun updateUserProfile(userId: Long, principal: UserPrincipal, request: UpdateUserRequest): UserResponse {
-        return userRepository.findById(userId)
-            ?.also { checkPermission(it, principal) }
+    fun updateUserProfile(
+        userId: Long,
+        principal: UserPrincipal,
+        request: UpdateUserRequest
+    ): UserResponse {
+        return userRepository.findById(userId)?.also { checkPermission(it, principal) }
             ?.also { request.apply(it) }
-            ?.let { UserResponse.from(it) }
-            ?: throw ModelNotFoundException("User not found with id", userId)
+            ?.let { UserResponse.from(it) } ?: throw ModelNotFoundException("User not found with id", userId)
     }
 
     @Transactional
     fun tokenTestGenerate(): SignInResponse {
-        return (userRepository.findById(1)
-            ?: userRepository.save(
-                User(
-                    username = "test",
-                    password = "12345678",
-                    profile = Profile(nickname = "testAdminNickname"),
-                    role = UserRole.ADMIN
-                )
-            ))
-            .let { SignInResponse.from(jwtPlugin = jwtPlugin, user = it) }
+        return (userRepository.findById(1) ?: userRepository.save(
+            User(
+                username = "test",
+                password = "12345678",
+                profile = Profile(nickname = "testAdminNickname"),
+                role = UserRole.ADMIN
+            )
+        )).let { SignInResponse.from(jwtPlugin = jwtPlugin, user = it) }
     }
 
     fun tokenTestCheck(accessToken: String, principal: UserPrincipal): TokenCheckResponse {
@@ -94,26 +93,23 @@ class UserService(
     fun subscribeChef(principal: UserPrincipal, chefId: Long): SubscriptionResponse {
         check(!subscriptionRepository.isSubscribed(principal.id, chefId)) { "Already subscribed" }
 
-        val chef = userRepository.findById(chefId)
-            ?: throw ModelNotFoundException("Chef not found with id", chefId)
+        val chef = userRepository.findById(chefId) ?: throw ModelNotFoundException("Chef not found with id", chefId)
 
         check(chef.role == UserRole.CHEF) { "User is not a chef" }
         check(chef.status == UserStatus.ACTIVE) { "Chef is not active" }
 
-        val user = userRepository.findById(principal.id)
-            ?: throw ModelNotFoundException("User not found with id", principal.id)
+        val user = userRepository.findById(principal.id) ?: throw ModelNotFoundException(
+            "User not found with id",
+            principal.id
+        )
 
         val subscription = Subscription(
             id = SubscriptionId(
-                userId = principal.id,
-                subscribedUserId = chefId
-            ),
-            user = user,
-            subscribedUser = chef
+                userId = principal.id, subscribedUserId = chefId
+            ), user = user, subscribedUser = chef
         )
 
-        return subscriptionRepository.subscribe(subscription)
-            .let { SubscriptionResponse.from(it) }
+        return subscriptionRepository.subscribe(subscription).let { SubscriptionResponse.from(it) }
     }
 
     @Transactional
@@ -128,8 +124,7 @@ class UserService(
     private fun checkPermission(user: User, principal: UserPrincipal) {
         check(
             user.checkPermission(
-                principal.id,
-                principal.role
+                principal.id, principal.role
             )
         ) { throw AccessDeniedException("You do not own this user") }
     }

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/s3/CustomJackson2HttpMessageConverter.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/s3/CustomJackson2HttpMessageConverter.kt
@@ -1,0 +1,25 @@
+package team.sparta.onehouronemeal.infra.s3
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.http.MediaType
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter
+import org.springframework.lang.Nullable
+import org.springframework.stereotype.Component
+import java.lang.reflect.Type
+
+
+@Component
+class CustomJackson2HttpMessageConverter(objectMapper: ObjectMapper) :
+    AbstractJackson2HttpMessageConverter(objectMapper, MediaType.APPLICATION_OCTET_STREAM) {
+    override fun canWrite(clazz: Class<*>, @Nullable mediaType: MediaType?): Boolean {
+        return false
+    }
+
+    override fun canWrite(@Nullable type: Type?, clazz: Class<*>, @Nullable mediaType: MediaType?): Boolean {
+        return false
+    }
+
+    override fun canWrite(mediaType: MediaType?): Boolean {
+        return false
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/s3/S3Config.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/s3/S3Config.kt
@@ -1,0 +1,27 @@
+package team.sparta.onehouronemeal.infra.s3
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class S3Config(
+    @Value("\${cloud.aws.credentials.access-key}") val accessKey: String,
+    @Value("\${cloud.aws.credentials.secret-key}") val secretKey: String,
+    @Value("\${cloud.aws.region.static}") val region: String
+) {
+    @Bean
+    fun amazonS3Client(): AmazonS3Client {
+        val credentials = BasicAWSCredentials(accessKey, secretKey)
+
+        return AmazonS3ClientBuilder
+            .standard()
+            .withRegion(region)
+            .withCredentials(AWSStaticCredentialsProvider(credentials))
+            .build() as AmazonS3Client
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/s3/S3FileManagement.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/s3/S3FileManagement.kt
@@ -1,0 +1,55 @@
+package team.sparta.onehouronemeal.infra.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ObjectMetadata
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.util.*
+
+@Component
+class S3FileManagement(
+    @Value("\${cloud.aws.s3.bucket}")
+    private val bucket: String,
+    private val amazonS3: AmazonS3,
+) {
+    fun uploadImage(multipartFile: MultipartFile): String {
+        val originalFilename = multipartFile.originalFilename
+            ?: throw IllegalArgumentException("The image file name is incorrect or missing.")
+
+        checkImageFormat(originalFilename)
+
+        val fileName = "${UUID.randomUUID()}-${originalFilename}"
+
+        val objectMetadata = setFileDateOption(
+            multipartFile = multipartFile
+        )
+
+        amazonS3.putObject(bucket, fileName, multipartFile.inputStream, objectMetadata)
+
+        return fileName
+    }
+
+    fun getUrl(fileName: String): String {
+        return amazonS3.getUrl(bucket, fileName).toString()
+    }
+
+    fun delete(fileName: String) {
+        amazonS3.deleteObject(bucket, fileName)
+    }
+
+    private fun setFileDateOption(
+        multipartFile: MultipartFile
+    ): ObjectMetadata {
+        val objectMetadata = ObjectMetadata()
+        objectMetadata.contentType = "image/jpeg"
+        objectMetadata.contentLength = multipartFile.inputStream.available().toLong()
+        objectMetadata.contentDisposition = "inline"
+        return objectMetadata
+    }
+
+    private fun checkImageFormat(fileName: String) {
+        val regex = Regex("""(?i)\.(jpg|jpeg|png|gif|bmp|webp)$""")
+        if (!regex.containsMatchIn(fileName)) throw IllegalArgumentException("Invalid file format: $fileName")
+    }
+}


### PR DESCRIPTION
## 요약
AWS S3 저장소를 이용해 프로필 이미지 저장을 구현하였습니다.

## 작업 사항

- 회원가입시 프로필 이미지(업로드 하지 않아도 괜찮음)을 업로드할 수 있습니다. DB에 이미지 Url 주소가 저장됩니다.
- 프로필 수정 API를 이용해 프로필 이미지 사진을 업로드, 변경 할 수 있습니다.

## 리뷰 요청 사항(선택)

현재 한 번 저장소에 올라간 사진은 삭제가 되지 않도록 되어있습니다. (삭제는 구현하기 쉽습니다.) 유저 테이블에는 프로필 Url만 저장되거나 수정됩니다. 아이디어가 있으시면 남겨주세요

---
### 해결한 이슈
closes: #31 
