### PR TITLE
✨ 이전 패스워드에 대한 처리

### DIFF
--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
@@ -5,9 +5,23 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
-import team.sparta.onehouronemeal.domain.user.dto.v1.*
+import team.sparta.onehouronemeal.domain.user.dto.v1.SignInRequest
+import team.sparta.onehouronemeal.domain.user.dto.v1.SignInResponse
+import team.sparta.onehouronemeal.domain.user.dto.v1.SignUpRequest
+import team.sparta.onehouronemeal.domain.user.dto.v1.SubscriptionResponse
+import team.sparta.onehouronemeal.domain.user.dto.v1.TokenCheckResponse
+import team.sparta.onehouronemeal.domain.user.dto.v1.UpdateUserRequest
+import team.sparta.onehouronemeal.domain.user.dto.v1.UserResponse
 import team.sparta.onehouronemeal.domain.user.service.v1.UserService
 import team.sparta.onehouronemeal.infra.security.UserPrincipal
 
@@ -24,6 +38,7 @@ class UserController(
         @RequestPart("request") request: SignUpRequest,
         @RequestPart("image", required = false) image: MultipartFile?
     ): ResponseEntity<UserResponse> {
+        if (request.password != request.confirmPassword) throw IllegalArgumentException("Password not matched")
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.signUp(role, request, image))
     }
 
@@ -53,6 +68,7 @@ class UserController(
         @RequestPart("request") request: UpdateUserRequest,
         @RequestPart("image", required = false) image: MultipartFile?
     ): ResponseEntity<UserResponse> {
+        if (request.password != request.confirmPassword) throw IllegalArgumentException("Password not matched")
         return ResponseEntity.status(HttpStatus.OK)
             .body(userService.updateUserProfile(userId, principal, request, image))
     }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
@@ -43,7 +43,7 @@ class UserController(
     }
 
     @PostMapping("/auth/sign-in")
-    fun signUpUser(@RequestBody request: SignInRequest): ResponseEntity<SignInResponse> {
+    fun signInUser(@RequestBody request: SignInRequest): ResponseEntity<SignInResponse> {
         return ResponseEntity.status(HttpStatus.OK).body(userService.signIn(request))
     }
 

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/SignUpRequest.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/SignUpRequest.kt
@@ -9,6 +9,7 @@ import team.sparta.onehouronemeal.domain.user.model.v1.UserStatus
 data class SignUpRequest(
     val username: String,
     val password: String,
+    val confirmPassword: String,
     val nickname: String
 ) {
     fun to(encoder: PasswordEncoder, role: String, imageUrl: String?): User {

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/UpdateUserRequest.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/UpdateUserRequest.kt
@@ -1,12 +1,16 @@
 package team.sparta.onehouronemeal.domain.user.dto.v1
 
+import org.springframework.security.crypto.password.PasswordEncoder
 import team.sparta.onehouronemeal.domain.user.model.v1.Profile
 import team.sparta.onehouronemeal.domain.user.model.v1.User
 
 data class UpdateUserRequest(
-    val nickname: String
+    val nickname: String,
+    val password: String,
+    val confirmPassword: String
 ) {
-    fun apply(user: User, imageUrl: String?) {
+    fun apply(encoder: PasswordEncoder, user: User, imageUrl: String?) {
         user.updateProfile(Profile(nickname, imageUrl))
+        user.updatePassword(encoder.encode(password))
     }
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/UpdateUserRequest.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/UpdateUserRequest.kt
@@ -11,6 +11,8 @@ data class UpdateUserRequest(
 ) {
     fun apply(encoder: PasswordEncoder, user: User, imageUrl: String?) {
         user.updateProfile(Profile(nickname, imageUrl))
-        user.updatePassword(encoder.encode(password))
+        if (password.isNotEmpty() && password == confirmPassword) {
+            user.updatePassword(encoder.encode(password))
+        }
     }
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/User.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/User.kt
@@ -20,8 +20,8 @@ class User(
     val username: String,
 
     @Column(name = "password")
-    @Size(max = 60)
-    val password: String,
+    @Size(max = 50)
+    var password: String,
 
     @Embedded
     var profile: Profile,
@@ -48,6 +48,10 @@ class User(
 
     fun checkPermission(userId: Long, role: String): Boolean {
         return this.id == userId || role == "ROLE_ADMIN"
+    }
+
+    fun updatePassword(password: String) {
+        this.password = password
     }
 
     fun updateProfile(profile: Profile) {

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/passwordhistory/PasswordHistory.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/passwordhistory/PasswordHistory.kt
@@ -1,0 +1,34 @@
+package team.sparta.onehouronemeal.domain.user.model.v1.passwordhistory
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.validation.constraints.Size
+import org.hibernate.annotations.CreationTimestamp
+import team.sparta.onehouronemeal.domain.user.model.v1.User
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "password_history")
+data class PasswordHistory(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    val user: User,
+
+    @Column(name = "password")
+    @Size(max = 50)
+    val password: String,
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/passwordhistory/PasswordHistoryJpaRepository.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/passwordhistory/PasswordHistoryJpaRepository.kt
@@ -1,0 +1,8 @@
+package team.sparta.onehouronemeal.domain.user.repository.v1.passwordhistory
+
+import org.springframework.data.jpa.repository.JpaRepository
+import team.sparta.onehouronemeal.domain.user.model.v1.passwordhistory.PasswordHistory
+
+interface PasswordHistoryJpaRepository : JpaRepository<PasswordHistory, Long> {
+    fun deleteAllByUserId(userId: Long)
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/passwordhistory/PasswordHistoryRepository.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/passwordhistory/PasswordHistoryRepository.kt
@@ -1,0 +1,11 @@
+package team.sparta.onehouronemeal.domain.user.repository.v1.passwordhistory
+
+import team.sparta.onehouronemeal.domain.user.model.v1.passwordhistory.PasswordHistory
+
+interface PasswordHistoryRepository {
+    fun save(passwordHistory: PasswordHistory): PasswordHistory
+    fun findLastThreePasswordsByUserId(userId: Long): List<String>
+    fun deleteByUserId(userId: Long)
+    fun deleteByIds(ids: List<Long>)
+    fun deleteHistoriesIfCountOver(userId: Long)
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/passwordhistory/PasswordHistoryRepositoryImpl.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/passwordhistory/PasswordHistoryRepositoryImpl.kt
@@ -1,0 +1,52 @@
+package team.sparta.onehouronemeal.domain.user.repository.v1.passwordhistory
+
+import org.springframework.stereotype.Repository
+import team.sparta.onehouronemeal.domain.user.model.v1.passwordhistory.PasswordHistory
+import team.sparta.onehouronemeal.domain.user.model.v1.passwordhistory.QPasswordHistory
+import team.sparta.onehouronemeal.infra.querydsl.QueryDslSupport
+
+@Repository
+class PasswordHistoryRepositoryImpl(
+    private val passwordHistoryJpaRepository: PasswordHistoryJpaRepository
+) : PasswordHistoryRepository, QueryDslSupport() {
+    val passwordHistory = QPasswordHistory.passwordHistory
+
+    override fun save(passwordHistory: PasswordHistory): PasswordHistory {
+        return passwordHistoryJpaRepository.save(passwordHistory)
+    }
+
+    override fun findLastThreePasswordsByUserId(userId: Long): List<String> {
+        return queryFactory
+            .select(passwordHistory.password)
+            .from(passwordHistory)
+            .where(passwordHistory.user.id.eq(userId))
+            .orderBy(passwordHistory.createdAt.desc())
+            .limit(3)
+            .fetch()
+    }
+
+    override fun deleteByUserId(userId: Long) {
+        passwordHistoryJpaRepository.deleteAllByUserId(userId)
+    }
+
+    override fun deleteByIds(ids: List<Long>) {
+        passwordHistoryJpaRepository.deleteAllById(ids)
+    }
+
+    override fun deleteHistoriesIfCountOver(userId: Long) {
+        val deleteIds = queryFactory
+            .select(passwordHistory.id)
+            .from(passwordHistory)
+            .where(passwordHistory.user.id.eq(userId))
+            .orderBy(passwordHistory.createdAt.desc())
+            .offset(3)
+            .fetch()
+
+        if (deleteIds.isNotEmpty()) {
+            queryFactory
+                .delete(passwordHistory)
+                .where(passwordHistory.id.`in`(deleteIds))
+                .execute()
+        }
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -93,7 +93,11 @@ class UserService(
                 }
             }
             ?.also { request.apply(passwordEncoder, it, imageFileUrl) }
-            ?.also { passwordHistoryService.savePasswordHistory(it) }
+            ?.also {
+                if (request.password.isNotEmpty()) {
+                    passwordHistoryService.savePasswordHistory(it)
+                }
+            }
             ?.let { UserResponse.from(it) }
             ?: throw ModelNotFoundException("User not found with id", userId)
     }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -87,7 +87,11 @@ class UserService(
 
         return userRepository.findById(userId)
             ?.also { checkPermission(it, principal) }
-            ?.also { passwordHistoryService.checkPasswordChange(it.id!!, request.password) }
+            ?.also {
+                if (request.password.isNotEmpty()) {
+                    passwordHistoryService.checkPasswordChange(it.id!!, request.password)
+                }
+            }
             ?.also { request.apply(passwordEncoder, it, imageFileUrl) }
             ?.also { passwordHistoryService.savePasswordHistory(it) }
             ?.let { UserResponse.from(it) }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/passwordhistory/PasswordHistoryService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/passwordhistory/PasswordHistoryService.kt
@@ -1,0 +1,40 @@
+package team.sparta.onehouronemeal.domain.user.service.v1.passwordhistory
+
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import team.sparta.onehouronemeal.domain.user.model.v1.User
+import team.sparta.onehouronemeal.domain.user.model.v1.passwordhistory.PasswordHistory
+import team.sparta.onehouronemeal.domain.user.repository.v1.passwordhistory.PasswordHistoryRepository
+
+@Service
+class PasswordHistoryService(
+    private val passwordHistoryRepository: PasswordHistoryRepository,
+    private val encoder: PasswordEncoder
+) {
+    fun checkPasswordChange(userId: Long, newPassword: String) {
+        check(
+            passwordHistoryRepository
+                .findLastThreePasswordsByUserId(userId)
+                .none { encoder.matches(newPassword, it) }
+        ) { "Password cannot be the same as the last three passwords" }
+    }
+
+    fun savePasswordHistory(user: User) {
+        passwordHistoryRepository.save(
+            PasswordHistory(
+                user = user,
+                password = user.password
+            )
+        )
+
+        passwordHistoryRepository.deleteHistoriesIfCountOver(user.id!!)
+    }
+
+    fun deleteAllByUserId(userId: Long) {
+        passwordHistoryRepository.deleteByUserId(userId)
+    }
+
+    fun deleteAllById(ids: List<Long>) {
+        passwordHistoryRepository.deleteByIds(ids)
+    }
+}


### PR DESCRIPTION
## 요약
> 간단 요약

이전 패스워드 3회에 대한 변경을 막습니다.
이전 패스워드 테이블에 해당 유저가 패스워드 3개를 초과하면 삭제와 생성을 함께 진행합니다.
QueryDSL을 사용했습니다

## 작업 사항

> PR에서 작업한 사항들을 적어주세요(이미지, 스크린샷등을 활용해도 좋아요)

비밀번호 수정에 password, confirmPassword 추가해서 수정 가능하게 만들기
 이전 비밀번호 검증 처리
 이전 비밀번호 3회 이상 쌓이면 제거하기

## 리뷰 요청 사항(선택)

> 리뷰시 봐주었으면 하는 부분이 있다면 적어주세요

---
### 해결한 이슈
closes: #32 
