### PR TITLE
✨ Refresh token을 저장하고 토큰 재발급 / 로그아웃을 할 수 있게 구현

### DIFF
--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
@@ -51,8 +51,8 @@ class UserController(
     }
 
     @PostMapping("/auth/sign-out")
-    fun signOutUser(): ResponseEntity<Unit> {
-        userService.signOut()
+    fun signOutUser(@AuthenticationPrincipal principal: UserPrincipal): ResponseEntity<Unit> {
+        userService.signOut(principal)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
+import team.sparta.onehouronemeal.domain.user.dto.v1.RefreshResponse
 import team.sparta.onehouronemeal.domain.user.dto.v1.SignInRequest
 import team.sparta.onehouronemeal.domain.user.dto.v1.SignInResponse
 import team.sparta.onehouronemeal.domain.user.dto.v1.SignUpRequest
@@ -57,7 +58,7 @@ class UserController(
     }
 
     @PostMapping("/auth/refresh-token")
-    fun refreshAccessToken(@RequestHeader("RefreshToken") refreshToken: String): ResponseEntity<SignInResponse> {
+    fun refreshAccessToken(@RequestHeader("RefreshToken") refreshToken: String): ResponseEntity<RefreshResponse> {
         if (!refreshTokenService.validateRefreshToken(refreshToken)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/controller/v1/UserController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
@@ -23,12 +24,14 @@ import team.sparta.onehouronemeal.domain.user.dto.v1.TokenCheckResponse
 import team.sparta.onehouronemeal.domain.user.dto.v1.UpdateUserRequest
 import team.sparta.onehouronemeal.domain.user.dto.v1.UserResponse
 import team.sparta.onehouronemeal.domain.user.service.v1.UserService
+import team.sparta.onehouronemeal.domain.user.service.v1.refreshtoken.RefreshTokenService
 import team.sparta.onehouronemeal.infra.security.UserPrincipal
 
 @RestController
 @RequestMapping("/api/v1")
 class UserController(
-    val userService: UserService
+    val userService: UserService,
+    val refreshTokenService: RefreshTokenService
 ) {
     @PostMapping(
         "/auth/sign-up/{role}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE]
@@ -51,6 +54,15 @@ class UserController(
     fun signOutUser(): ResponseEntity<Unit> {
         userService.signOut()
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+
+    @PostMapping("/auth/refresh-token")
+    fun refreshAccessToken(@RequestHeader("RefreshToken") refreshToken: String): ResponseEntity<SignInResponse> {
+        if (!refreshTokenService.validateRefreshToken(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(refreshTokenService.refreshAccessToken(refreshToken))
     }
 
     @GetMapping("/users/{userId}/profiles")

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/RefreshResponse.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/dto/v1/RefreshResponse.kt
@@ -1,0 +1,5 @@
+package team.sparta.onehouronemeal.domain.user.dto.v1
+
+data class RefreshResponse(
+    val accessToken: String
+)

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/refreshtoken/RefreshToken.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/refreshtoken/RefreshToken.kt
@@ -24,7 +24,7 @@ data class RefreshToken(
     @Column(name = "refresh_token", nullable = false)
     var refreshToken: String,
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @MapsId
     @JoinColumn(name = "user_id")
     val user: User

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/refreshtoken/RefreshToken.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/refreshtoken/RefreshToken.kt
@@ -1,0 +1,35 @@
+package team.sparta.onehouronemeal.domain.user.model.v1.refreshtoken
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.MapsId
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import team.sparta.onehouronemeal.domain.user.model.v1.User
+
+@Entity
+@Table(name = "refresh_token")
+data class RefreshToken(
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val userId: Long,
+
+    @Column(name = "refresh_token", nullable = false)
+    var refreshToken: String,
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+    @MapsId
+    @JoinColumn(name = "user_id")
+    val user: User
+) {
+    fun updateToken(token: String) {
+        refreshToken = token
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenJpaRepository.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenJpaRepository.kt
@@ -1,0 +1,9 @@
+package team.sparta.onehouronemeal.domain.user.repository.v1.refreshtoken
+
+import org.springframework.data.jpa.repository.JpaRepository
+import team.sparta.onehouronemeal.domain.user.model.v1.refreshtoken.RefreshToken
+
+interface RefreshTokenJpaRepository : JpaRepository<RefreshToken, Long> {
+    fun findByUserId(userId: Long): RefreshToken?
+    fun deleteByUserId(userId: Long)
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenRepository.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenRepository.kt
@@ -1,0 +1,10 @@
+package team.sparta.onehouronemeal.domain.user.repository.v1.refreshtoken
+
+import team.sparta.onehouronemeal.domain.user.model.v1.refreshtoken.RefreshToken
+
+interface RefreshTokenRepository {
+    fun findTokenByUserId(userId: Long): String?
+    fun updateToken(refreshToken: RefreshToken)
+    fun updateTokenByUserId(userId: Long, newToken: String)
+    fun deleteTokenByUserId(userId: Long)
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenRepository.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenRepository.kt
@@ -5,6 +5,5 @@ import team.sparta.onehouronemeal.domain.user.model.v1.refreshtoken.RefreshToken
 interface RefreshTokenRepository {
     fun findTokenByUserId(userId: Long): String?
     fun updateToken(refreshToken: RefreshToken)
-    fun updateTokenByUserId(userId: Long, newToken: String)
     fun deleteTokenByUserId(userId: Long)
 }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenRepositoryImpl.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenRepositoryImpl.kt
@@ -17,10 +17,6 @@ class RefreshTokenRepositoryImpl(
             ?: refreshTokenJpaRepository.save(refreshToken)
     }
 
-    override fun updateTokenByUserId(userId: Long, newToken: String) {
-        refreshTokenJpaRepository.findByUserId(userId)?.updateToken(newToken)
-    }
-
     override fun deleteTokenByUserId(userId: Long) {
         refreshTokenJpaRepository.deleteByUserId(userId)
     }

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenRepositoryImpl.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/repository/v1/refreshtoken/RefreshTokenRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package team.sparta.onehouronemeal.domain.user.repository.v1.refreshtoken
+
+import org.springframework.stereotype.Repository
+import team.sparta.onehouronemeal.domain.user.model.v1.refreshtoken.RefreshToken
+
+@Repository
+class RefreshTokenRepositoryImpl(
+    private val refreshTokenJpaRepository: RefreshTokenJpaRepository
+) : RefreshTokenRepository {
+    override fun findTokenByUserId(userId: Long): String? {
+        return refreshTokenJpaRepository.findByUserId(userId)?.refreshToken
+    }
+
+    override fun updateToken(refreshToken: RefreshToken) {
+        refreshTokenJpaRepository.findByUserId(refreshToken.userId)
+            ?.updateToken(refreshToken.refreshToken)
+            ?: refreshTokenJpaRepository.save(refreshToken)
+    }
+
+    override fun updateTokenByUserId(userId: Long, newToken: String) {
+        refreshTokenJpaRepository.findByUserId(userId)?.updateToken(newToken)
+    }
+
+    override fun deleteTokenByUserId(userId: Long) {
+        refreshTokenJpaRepository.deleteByUserId(userId)
+    }
+}

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -68,8 +68,8 @@ class UserService(
     }
 
     @Transactional
-    fun signOut() {
-        TODO("추후 Refresh token 관련 로직과 함께 구현")
+    fun signOut(principal: UserPrincipal) {
+        refreshTokenService.deleteRefreshToken(principal.id)
     }
 
     fun getUserProfile(userId: Long, principal: UserPrincipal): UserResponse {

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -20,6 +20,7 @@ import team.sparta.onehouronemeal.domain.user.model.v1.subscription.Subscription
 import team.sparta.onehouronemeal.domain.user.repository.v1.UserRepository
 import team.sparta.onehouronemeal.domain.user.repository.v1.subscription.SubscriptionRepository
 import team.sparta.onehouronemeal.domain.user.service.v1.passwordhistory.PasswordHistoryService
+import team.sparta.onehouronemeal.domain.user.service.v1.refreshtoken.RefreshTokenService
 import team.sparta.onehouronemeal.exception.AccessDeniedException
 import team.sparta.onehouronemeal.exception.ModelNotFoundException
 import team.sparta.onehouronemeal.infra.oauth.client.dto.OAuth2UserInfo
@@ -33,6 +34,7 @@ class UserService(
     private val subscriptionRepository: SubscriptionRepository,
 
     private val passwordHistoryService: PasswordHistoryService,
+    private val refreshTokenService: RefreshTokenService,
 
     private val passwordEncoder: PasswordEncoder,
     private val jwtPlugin: JwtPlugin,
@@ -57,7 +59,11 @@ class UserService(
     fun signIn(request: SignInRequest): SignInResponse {
         return userRepository.findByUsername(request.username)
             ?.also { check(passwordEncoder.matches(request.password, it.password)) { "Password not matched" } }
-            ?.let { SignInResponse.from(jwtPlugin, it) }
+            ?.let {
+                val response = SignInResponse.from(jwtPlugin, it)
+                refreshTokenService.updateRefreshToken(response.refreshToken, it)
+                return response
+            }
             ?: throw IllegalArgumentException("User not found with username")
     }
 
@@ -122,10 +128,14 @@ class UserService(
     }
 
     fun registerIfAbsentWithOAuth(info: OAuth2UserInfo): SignInResponse {
-        return run {
+        run {
             userRepository.findByProviderAndProviderId(info.provider.name, info.id)
                 ?: userRepository.save(info.to(passwordEncoder))
-        }.let { SignInResponse.from(jwtPlugin, it) }
+        }.let {
+            val response = SignInResponse.from(jwtPlugin, it)
+            refreshTokenService.updateRefreshToken(response.refreshToken, it)
+            return response
+        }
     }
 
     fun subscribeChef(principal: UserPrincipal, chefId: Long): SubscriptionResponse {

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/refreshtoken/RefreshTokenService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/refreshtoken/RefreshTokenService.kt
@@ -1,0 +1,77 @@
+package team.sparta.onehouronemeal.domain.user.service.v1.refreshtoken
+
+import io.jsonwebtoken.Claims
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.sparta.onehouronemeal.domain.user.dto.v1.SignInResponse
+import team.sparta.onehouronemeal.domain.user.model.v1.User
+import team.sparta.onehouronemeal.domain.user.model.v1.refreshtoken.RefreshToken
+import team.sparta.onehouronemeal.domain.user.repository.v1.refreshtoken.RefreshTokenRepository
+import team.sparta.onehouronemeal.infra.security.jwt.JwtPlugin
+
+@Service
+class RefreshTokenService(
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val jwtPlugin: JwtPlugin
+) {
+    fun validateRefreshToken(token: String): Boolean {
+        return jwtPlugin.validateToken(token).isSuccess
+    }
+
+    @Transactional
+    fun refreshAccessToken(refreshToken: String): SignInResponse {
+        return getValidatedPayload(refreshToken)
+            .run {
+                val userId = subject.toLong()
+                val role = get("role", String::class.java)
+                userId to role
+            }
+            .also { (userId, _) -> checkRefreshToken(userId, refreshToken) }
+            .let { (userId, role) -> generateNewTokens(userId, role) }
+            .let { (accessToken, refreshToken) ->
+                SignInResponse(
+                    accessToken = accessToken,
+                    refreshToken = refreshToken
+                )
+            }
+    }
+
+    fun updateRefreshToken(token: String, user: User) {
+        refreshTokenRepository.updateToken(
+            RefreshToken(
+                userId = user.id!!,
+                refreshToken = token,
+                user = user
+            )
+        )
+    }
+
+    fun deleteRefreshToken(userId: Long) {
+        refreshTokenRepository.deleteTokenByUserId(userId)
+    }
+
+    private fun getValidatedPayload(refreshToken: String): Claims {
+        val jwtValidationResult = jwtPlugin.validateToken(refreshToken)
+        if (jwtValidationResult.isFailure) {
+            throw IllegalArgumentException("Invalid refresh token")
+        }
+
+        return jwtValidationResult.getOrNull()?.payload
+            ?: throw IllegalArgumentException("Invalid refresh token")
+    }
+
+    private fun checkRefreshToken(userId: Long, refreshToken: String) {
+        if (refreshTokenRepository.findTokenByUserId(userId) != refreshToken) {
+            throw IllegalArgumentException("Refresh token unmatched")
+        }
+    }
+
+    private fun generateNewTokens(userId: Long, role: String): Pair<String, String> {
+        val accessToken = jwtPlugin.generateAccessToken(userId.toString(), role)
+        val refreshToken = jwtPlugin.generateRefreshToken(userId.toString(), role)
+        refreshTokenRepository.updateTokenByUserId(userId, refreshToken)
+
+        return accessToken to refreshToken
+    }
+}
+

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/security/jwt/JwtAuthenticationFilter.kt
@@ -1,5 +1,6 @@
 package team.sparta.onehouronemeal.infra.security.jwt
 
+import io.jsonwebtoken.ExpiredJwtException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -43,6 +44,19 @@ class JwtAuthenticationFilter(
                     )
 
                     SecurityContextHolder.getContext().authentication = authentication
+                }
+                .onFailure { exception ->
+                    when (exception) {
+                        is ExpiredJwtException -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token expired")
+                        }
+
+                        else -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token")
+                        }
+                    }
+
+                    return
                 }
         }
 

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/security/jwt/JwtAuthenticationFilter.kt
@@ -32,6 +32,12 @@ class JwtAuthenticationFilter(
                 .onSuccess {
                     val userId = it.payload.subject.toLong()
                     val role = it.payload.get("role", String::class.java)
+                    val type = it.payload.get("type", String::class.java)
+
+                    if (type != JwtPlugin.ACCESS_TOKEN_TYPE) {
+                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token type")
+                        return
+                    }
 
                     val principal = UserPrincipal(
                         id = userId,

--- a/src/main/kotlin/team/sparta/onehouronemeal/infra/security/jwt/JwtPlugin.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/infra/security/jwt/JwtPlugin.kt
@@ -18,6 +18,10 @@ class JwtPlugin(
     @Value("\${auth.jwt.accessTokenExpirationHour}") private val accessTokenExpirationHour: Long,
     @Value("\${auth.jwt.refreshTokenExpirationHour}") private val refreshTokenExpirationHour: Long,
 ) {
+    companion object {
+        const val ACCESS_TOKEN_TYPE = "access"
+        const val REFRESH_TOKEN_TYPE = "refresh"
+    }
 
     fun validateToken(jwt: String): Result<Jws<Claims>> {
         return kotlin.runCatching {
@@ -27,15 +31,15 @@ class JwtPlugin(
     }
 
     fun generateAccessToken(subject: String, role: String): String {
-        return generateToken(subject, role, Duration.ofHours(accessTokenExpirationHour))
+        return generateToken(subject, role, ACCESS_TOKEN_TYPE, Duration.ofHours(accessTokenExpirationHour))
     }
 
     fun generateRefreshToken(subject: String, role: String): String {
-        return generateToken(subject, role, Duration.ofHours(refreshTokenExpirationHour))
+        return generateToken(subject, role, REFRESH_TOKEN_TYPE, Duration.ofHours(refreshTokenExpirationHour))
     }
 
-    private fun generateToken(subject: String, role: String, expirationPeriod: Duration): String {
-        val claims: Claims = Jwts.claims().add(mapOf("role" to role)).build()
+    private fun generateToken(subject: String, role: String, type: String, expirationPeriod: Duration): String {
+        val claims: Claims = Jwts.claims().add(mapOf("role" to role, "type" to type)).build()
 
         val now = Instant.now()
         val key = Keys.hmacShaKeyFor(secret.toByteArray(StandardCharsets.UTF_8))


### PR DESCRIPTION
## 요약
> 간단 요약

User와 OneToOne 으로 구성되어 있는 RefreshToken Entity로 

1. 유저가 로그인시 Refresh token을 저장합니다
2. Access token이 만료되면 Exception이 발생하고 클라이언트는 /auth/refresh-token 으로 "RefreshToken" header에 refresh token을 담아 보냅니다.
3. refresh token이 만료되지 않은 상태라면 새로운 AccessToken / RefreshToken을 발급해 클라이언트에 반환합니다.
  3-1. Refresh token이 재발급됨으로서 로그인 세션의 유지 기간이 늘어나는 기능도 겸합니다. 
  3-2. Refresh token도 만료된 상태라면 토큰 재발급이 불가능하므로 로그아웃 된 상태로 간주됩니다.
5. DB의 Refresh token도 새롭게 갱신합니다.
6. 로그아웃시 DB의 Refresh token을 삭제합니다. 
  6-1. Refresh token이 만료되기 전까지는 Access token을 계속 사용할 수 있는 상태인 건 어쩔 수 없습니다.

JWT에 type: "access", "refresh" 를 구분해 이제 Refresh token으로 인증이 불가능합니다.
조사해보니 Security Filter에서 만료를 검증하고 즉시 재발급해 Response에 담아 보내는 방법도 존재하나
- 클라이언트가 Access Token + Refresh Token을 요청에 계속 담아 보내면 둘 다 탈취당할 위험이 커짐
- 요청마다 알아서 무한으로 재발급 될거면 Refresh token, Expire의 의미가 퇴색됨
등의 이유로 Client가 Refresh 로직을 구현하는게 안전하다고 합니다.


## 작업 사항

> PR에서 작업한 사항들을 적어주세요(이미지, 스크린샷등을 활용해도 좋아요)

 Refresh 토큰 처리 (Access token 재발급 포함)
 로그아웃 구현
 Token type 구분

## 리뷰 요청 사항(선택)

> 리뷰시 봐주었으면 하는 부분이 있다면 적어주세요

추가로 @OneToOne 관계의 트러블슈팅이 좀 있었는데
양방향이 아님에도 Cascade를 진행해야 로그인시 User Entity의 정보를 Hibernate가 확실히 체크하고 관계를 맺어주는 이슈가 있었습니다. [Assertion failure null identifier](https://stackoverflow.com/questions/28508385/org-hibernate-assertionfailure-null-identifier-onetoone-relationship)
이후 CascadeType.ALL로 진행하면 로그아웃으로 Refresh token을 삭제할 때 User에 전파하려고 하는 이슈도 있어
준영속 상태의 User를 즉시 반영하는 CascadeType.MERGE 만 사용했습니다. (테스트 결과 Persist는 필요없는 것 같습니다.)

단방향이라 Cascade를 의심 할 생각이 없어 이걸로 고생좀 했는데 JPA가 이해하는 @OneToOne 관계에 대해 혹시 알려주실 분 있으면 저 좀 알려주세요 땡큐

---
### 해결한 이슈
closes: #26
