### PR TITLE
:bug: ACTIVE 상태가 아닌 User가 로그인 하지 못하도록 수정

### DIFF
--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/User.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/model/v1/User.kt
@@ -1,6 +1,14 @@
 package team.sparta.onehouronemeal.domain.user.model.v1
 
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
 import jakarta.validation.constraints.Size
 import team.sparta.onehouronemeal.domain.common.BaseTimeEntity
 
@@ -62,6 +70,10 @@ class User(
         this.status = status
 
         this.validate()
+    }
+
+    fun isActive(): Boolean {
+        return this.status == UserStatus.ACTIVE
     }
 
     private fun validate() {

--- a/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/team/sparta/onehouronemeal/domain/user/service/v1/UserService.kt
@@ -59,6 +59,7 @@ class UserService(
     fun signIn(request: SignInRequest): SignInResponse {
         return userRepository.findByUsername(request.username)
             ?.also { check(passwordEncoder.matches(request.password, it.password)) { "Password not matched" } }
+            ?.also { check(it.isActive()) { throw AccessDeniedException("가입 승인이 되지 않았습니다.") } }
             ?.let {
                 val response = SignInResponse.from(jwtPlugin, it)
                 refreshTokenService.updateRefreshToken(response.refreshToken, it)


### PR DESCRIPTION
## 요약
ACTIVE 상태가 아닌 User가 로그인 하지 못하도록 수정

## 작업 사항
- User 엔티티에 ACTIVE 상태 확인 메소드 추가 (isActive)
- UserServie.signIn 메소드에서 User의 상태 확인  

---
### 해결한 이슈
closes: #94 
